### PR TITLE
fix(icd): fix IOSHistory timestamp truncation and sort crash on 4-char TZ with Python 3.11+

### DIFF
--- a/naft/modules/icd.py
+++ b/naft/modules/icd.py
@@ -245,8 +245,13 @@ def IOSHistory(coredumpFilename, arguments=None):
     for command in FilterInitBlocksForString(coredumpFilename, b'CMD: '):
         oMatch = re.search(b"'(.+)' (.+)", command)
         if oMatch:
-            history.append((uf.ParseDateTime(oMatch.group(2).decode('utf-8')[0:28], hist_time_format), oMatch.group(1).decode('utf-8')))
-    for command in sorted(history, key=lambda x: datetime.strptime(x[0], hist_time_format)):
+            history.append((uf.ParseDateTime(oMatch.group(2).decode('utf-8')[0:32], hist_time_format), oMatch.group(1).decode('utf-8')))
+    def _ts_key(ts):
+        try:
+            return datetime.strptime(ts.rsplit(' ', 1)[0], '%b %d %Y %H:%M:%S.%f')
+        except ValueError:
+            return datetime.min
+    for command in sorted(history, key=lambda x: _ts_key(x[0])):
         print('{}: {}'.format(command[0], command[1]))
     if not history:
         print('No history found')


### PR DESCRIPTION
## Problem

`naft core <dump> --history` crashes with:

```
ValueError: time data 'Jun 10 202 08:07:27.000000 AEST' does not match format '%b %d %Y %H:%M:%S.%f %Z'
```

Two bugs in `IOSHistory()`:

**Bug 1 — year truncation**: The `[0:28]` slice on the raw CMD timestamp is too short. A 4-char timezone abbreviation + 2-digit day produces a 29-char string (`08:07:27 AEST Wed Jun 10 2026`). The slice silently drops the last digit of the year (`...Jun 10 202`). `dateutil` then parses year 202, `strftime('%Y')` emits 3 chars on Linux, and Python 3.11+ `strptime` rejects it.

**Bug 2 — ambiguous TZ sort crash**: The `sorted()` key calls `datetime.strptime(x[0], hist_time_format)` where the format includes `%Z`. For ambiguous timezone abbreviations (`EST`, `PST`, `CST`, `IST`, `CET`, `JST`) that `dateutil` does not resolve, `strftime('%Z')` emits an empty string, causing `strptime` to crash on sort.

## Fix

1. Extend the slice from `[0:28]` to `[0:32]` — covers the 29-char maximum Cisco IOS CMD timestamp.
2. Replace the sort key with `_ts_key()`, which strips the trailing TZ token with `rsplit(' ', 1)[0]` and parses using `'%b %d %Y %H:%M:%S.%f'` (no `%Z`). Falls back to `datetime.min` for any remaining malformed entries so sorting never crashes.

## Tested against

- Cisco IOS 12.4(25d) crashdump (Dynamips/GNS3), timezone `AEST`/`AEDT`
- Verified `UTC`, `AEST`, `AEDT`, `GMT` pass; `EST`, `PST`, `CST`, `IST`, `CET`, `JST` now also sort correctly instead of crashing