### PR TITLE
fix(impf): add Cisco 3745 IOS 12.4(25d) PCB layout + robustness fixes

### DIFF
--- a/naft/modules/impf.py
+++ b/naft/modules/impf.py
@@ -310,6 +310,18 @@ class cCiscoCWStrings:
 class cIOSProcess:
 
     dFields = {
+                664: {
+                        'addressProcessName': ('>I', 0xC8),
+                        'PC':                 ('>I', 0x70),
+                        'Q':                  ('>I', 0xCC),
+                        'Ty':                 ('>I', 0x64),
+                        'Runtime':            ('>I', 0x9C),
+                        'Invoked':            ('>I', 0x250),
+                        'Stack1':             ('>I', 0x84),
+                        'Stack2':             ('>I', 0x80),
+                        'addressStackBlock':  ('>I', 0x00),
+                        'addressTTY':         ('>I', 0xF0),
+                     },
                 692: {
                         'addressProcessName': ('>I', 0xD0),
                         'PC':                 ('>I', 0x6C),
@@ -379,7 +391,7 @@ class cIOSProcess:
         self.error = ''
         self.processID = processID
         self.data = data
-        self.indexProcessEnd = self.data.find(cCiscoMagic.STR_PROCESS_END, 690, len(data))  # BEEFCAFE can appear early in the process as well, parse for one near end of known range
+        self.indexProcessEnd = self.data.find(cCiscoMagic.STR_PROCESS_END, 600, len(data))  # BEEFCAFE can appear early in the process as well, parse for one near end of known range
         if self.indexProcessEnd < 0:
             self.error = 'Error: parsing process structure, BEEFCAFE not found'
             return
@@ -397,8 +409,9 @@ class cIOSProcess:
             else:
                 self.Ty_str = cIOSProcess.Ty2Str(self.Ty)
             addressIter = self.addressStackBlock
-            while oIOSCoreDump.GetInteger32(addressIter) == 0xFFFFFFFF and addressIter - self.addressStackBlock <= self.Stack2:
-                addressIter += 4
+            if self.Stack2 is not None:
+                while oIOSCoreDump.GetInteger32(addressIter) == 0xFFFFFFFF and addressIter - self.addressStackBlock <= self.Stack2:
+                    addressIter += 4
             self.LowWaterMark = addressIter - self.addressStackBlock
             if self.addressTTY is None:
                 self.TTY = None


### PR DESCRIPTION
## Summary

Three fixes in `impf.py` that make `--processes` work on Cisco 3745 IOS 12.4(25d) crashdumps (currently fails for every process with `Error: parsing process structure, BEEFCAFE not found`).

## Fixes

### 1. Lower BEEFCAFE search start 690 → 600

The process control block end-marker (0xBEEFCAFE) appears at byte offset 664 in 3745 IOS 12.4(25d) dumps. The existing search started at offset 690, so the marker was never found.

Validated against 222 live process blocks from a real 3745 crashdump — BEEFCAFE appears at exactly offset 664 in every block with no earlier false hits.

⚠️ **Scope note:** This change affects all platforms. Validated only on Cisco 3745 IOS 12.4(25d). A false-positive window in bytes 600–689 for other platforms cannot be formally ruled out (no test corpus exists in this repo for other IOS versions).

### 2. Guard Stack2=None crash (heuristics path)

When the PCB layout is unknown and heuristics run, `Stack2` may remain `None`. The stack walk did `addressIter - addressStackBlock <= self.Stack2` which raises TypeError. The fix skips the walk when `Stack2 is None` — correct behavior since without a known bound the walk cannot be safely bounded.

### 3. Add dFields[664] — Cisco 3745 IOS 12.4(25d) MIPS BE

Field offsets derived statistically from 222 process blocks in a real crashdump:

| Field | Offset | Evidence |
|---|---|---|
| addressProcessName | 0xC8 | Confirmed by heuristics engine |
| PC | 0x70 | 6 unique code-segment pointers (0x623Axxxx range) |
| Ty | 0x64 | Values {0,1,4,6,7,8} = known IOS process types |
| Q | 0xCC | Values {1,2,3,4} — see note |
| Runtime | 0x9C | Crash writer=1.6ms vs Check heaps=4M ms |
| Invoked | 0x250 | Timers highest, Crash writer lowest |
| Stack2 | 0x80 | {3972, 6972, 10072} bytes |
| Stack1 | 0x84 | Similar to Stack2 |
| addressStackBlock | 0x00 | Consistent with all existing entries |
| addressTTY | 0xF0 | 7 non-zero (TTY-attached processes), 215 zero |

**Known display quirk — Q priority labels:** IOS 12.4(25d) priority encoding is `{1=Critical, 2=High, 3=Medium, 4=Low}` but `Q2Str()` maps `{2=C, 3=H, 4=M, 5=L}`. Critical-priority processes show as `1` instead of `C`. All other labels are correct. Display-only; no data corruption.

## Test plan

- [ ] `naft core <3745-dump> --processes` — process list populated with names, Ty, PC, Runtime, Invoked (no `?` fields)
- [ ] `naft core <3745-dump> --processes` — no TypeError crash
- [ ] If other IOS platform dumps available: verify no regression in BEEFCAFE detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)